### PR TITLE
fix encap skopeo copy due to undefined var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Login
         run: podman login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ${{ env.REGISTRY }}
       - name: Encapsulate
-        run: ./encap.sh fedora/${{ matrix.version }}/x86_64/silverblue ${{ env.REPO }}/${{ github.repository_owner }}/fedora-silverblue:${{ matrix.version }}
+        run: ./encap.sh fedora/${{ matrix.version }}/x86_64/silverblue ${{ env.REGISTRY }}/${{ github.repository_owner }}/fedora-silverblue:${{ matrix.version }}


### PR DESCRIPTION
switch `env.REPO` to `env.REGISTRY` as it is defined at the top

Signed-off-by: jbpratt <jbpratt78@gmail.com>

https://github.com/jbpratt/sync-fedora-ostree-containers/pkgs/container/fedora-silverblue

https://github.com/jbpratt/sync-fedora-ostree-containers/actions/runs/3174277566/jobs/5170870864