### PR TITLE
fix runv behavior to print less

### DIFF
--- a/encap.sh
+++ b/encap.sh
@@ -8,9 +8,7 @@ image=$1
 shift
 
 runv () {
-    set -x
-    echo "$@"
-    $@
+    ( set -x ; $@ )
 }
 
 cd $(mktemp -d -p /var/tmp)


### PR DESCRIPTION
`set -x` was never being turned off so everything was being printed after the first call to `runv`. I think this patch is the intended behavior but please let me know if this is incorrect! Opening a sub-shell for the command drops the options on close.

https://github.com/jbpratt/sync-fedora-ostree-containers/actions/runs/3174489838/jobs/5171345246

Signed-off-by: jbpratt <jbpratt78@gmail.com>

before:
```
+ echo skopeo inspect -n docker://ghcr.io/cgwalters/fedora-silverblue:36
+ skopeo inspect -n docker://ghcr.io/cgwalters/fedora-silverblue:36
+ container_commit=
+ test -s inspect.json
++ jq -r '.Labels["ostree.commit"]'
+ container_commit=
+ mkdir repo
+ ostree --repo=repo init --mode=bare-user
+ cat /etc/ostree/remotes.d/fedora.conf
+ runv ostree --repo=repo pull --commit-metadata-only fedora:fedora/36/x86_64/silverblue
ostree --repo=repo pull --commit-metadata-only fedora:fedora/36/x86_64/silverblue
+ set -x
+ echo ostree --repo=repo pull --commit-metadata-only fedora:fedora/36/x86_64/silverblue
+ ostree --repo=repo pull --commit-metadata-only fedora:fedora/36/x86_64/silverblue
2 metadata, 0 content objects fetched; 51 KiB transferred in 0 seconds; 0 bytes content written
++ ostree --repo=repo rev-parse fedora:fedora/36/x86_64/silverblue
+ current_commit=cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2
+ test cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 == ''
+ runv ostree --repo=repo pull fedora:fedora/36/x86_64/silverblue
+ set -x
+ echo ostree --repo=repo pull fedora:fedora/36/x86_64/silverblue
+ ostree --repo=repo pull fedora:fedora/36/x86_64/silverblue
ostree --repo=repo pull fedora:fedora/36/x86_64/silverblue
6947 metadata, 86422 content objects fetched; 1679048 KiB transferred in 112 seconds; 3.8?GB content written
+ runv rpm-ostree compose container-encapsulate --format-version 1 --repo repo cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 oci:tmp
rpm-ostree compose container-encapsulate --format-version 1 --repo repo cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 oci:tmp
+ set -x
+ echo rpm-ostree compose container-encapsulate --format-version 1 --repo repo cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 oci:tmp
+ rpm-ostree compose container-encapsulate --format-version 1 --repo repo cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 oci:tmp
```

after:

```
+ skopeo inspect -n docker://ghcr.io/jbpratt/fedora-silverblue:36
time="2022-10-03T13:23:27Z" level=fatal msg="Error parsing image name \"docker://ghcr.io/jbpratt/fedora-silverblue:36\": reading manifest 36 in ghcr.io/jbpratt/fedora-silverblue: manifest unknown"
+ ostree --repo=repo pull --commit-metadata-only fedora:fedora/36/x86_64/silverblue
2 metadata, 0 content objects fetched; 51 KiB transferred in 1 seconds; 0 bytes content written
+ ostree --repo=repo pull fedora:fedora/36/x86_64/silverblue
6947 metadata, 86422 content objects fetched; 1679048 KiB transferred in 117 seconds; 3.8?GB content written
+ rpm-ostree compose container-encapsulate --format-version 1 --repo repo cf6f4a177210c9ab448082fbe7c84aab98847e02d1e5faf7b71a3be3faf6b8c2 oci:tmp
86422 objects in 1229 packages (813 source)
```