### PR TITLE
Additionally build Kinoite images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
+        variant: [silverblue, kinoite]
         version: [36, 37]
     runs-on: ubuntu-latest
     container:
@@ -31,4 +32,4 @@ jobs:
       - name: Login
         run: podman login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ${{ env.REGISTRY }}
       - name: Encapsulate
-        run: ./encap.sh fedora/${{ matrix.version }}/x86_64/silverblue ${{ env.REGISTRY }}/${{ github.repository_owner }}/fedora-silverblue:${{ matrix.version }}
+        run: ./encap.sh fedora/${{ matrix.version }}/x86_64/${{ matrix.variant }} ${{ env.REGISTRY }}/${{ github.repository_owner }}/fedora-${{ matrix.variant }}:${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Automatic sync of Fedora silverblue containers
+# Automatic sync of Fedora Silverblue / Kinoite containers
 
 This is a temporary repository until https://pagure.io/releng/issue/11047
 is merged/implemented.
 
 This repository automatically polls the Fedora OSTree
-repositories for Fedora Silverblue and generates container images.
+repositories for Fedora Silverblue / Kinoite and generates container images.
 
-They're published at `ghcr.io/cgwalters/fedora-silverblue:36` and
-`ghcr.io/cgwalters/fedora-silverblue:37`.
+They're published at `ghcr.io/cgwalters/fedora-silverblue:36`,
+`ghcr.io/cgwalters/fedora-silverblue:37`, `ghcr.io/cgwalters/fedora-kinoite:36`,
+and `ghcr.io/cgwalters/fedora-kinoite:37`.


### PR DESCRIPTION
It looks like until [this](https://www.fedoraproject.org/wiki/Changes/OstreeNativeContainerStable) proposed change lands in Fedora 38, this repository is the semi-official location for OCI images of Silverblue.

It would also be fun to play around with Kinoite images, which is why this PR expands the workflow matrix to build two additional images (`fedora-kinoite:36` and `fedora-kinoite:37`), bringing the total job count up to 4.

I tested these changes in a fork of this repository [here](https://github.com/ahgencer/sync-fedora-ostree-containers/actions/workflows/build.yml). The tests seem to all pass, except for some network flakiness I encountered when pushing the `fedora-silverblue:36` image (though the build itself went smoothly).

I also updated the README to mention the new Kinoite images.