### PR TITLE
Build and tag Rawhide versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 1
       matrix:
         variant: [silverblue, kinoite]
-        version: [36, 37]
+        version: [36, 37, rawhide]
     runs-on: ubuntu-latest
     container:
       # We're using coreos-assembler just since it is a pre-made

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ is merged/implemented.
 This repository automatically polls the Fedora OSTree
 repositories for Fedora Silverblue / Kinoite and generates container images.
 
-They're published at `ghcr.io/cgwalters/fedora-silverblue:36`,
-`ghcr.io/cgwalters/fedora-silverblue:37`, `ghcr.io/cgwalters/fedora-kinoite:36`,
-and `ghcr.io/cgwalters/fedora-kinoite:37`.
+Here's a list of published images and their tags:
+
+|                 Image                 |         Tags          |
+|:-------------------------------------:|:---------------------:|
+| `ghcr.io/cgwalters/fedora-silverblue` | `36`, `37`, `rawhide` | 
+|  `ghcr.io/cgwalters/fedora-kinoite`   | `36`, `37`, `rawhide` | 


### PR DESCRIPTION
While we wait for https://pagure.io/releng/pull-request/11180 to get merged (what is it even still waiting for?), can we also publish Rawhide images? With this, we cover all currently supported versions of Fedora's immutable desktop editions.

This change adds two more images to the workflow: `fedora-silverblue:rawhide` and `fedora-kinoite:rawhide`