### PR TITLE
Add fedora 38 branched builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 1
       matrix:
         variant: [silverblue, kinoite]
-        version: [36, 37, rawhide]
+        version: [36, 37, 38, rawhide]
     runs-on: ubuntu-latest
     container:
       # We're using coreos-assembler just since it is a pre-made

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ Here's a list of published images and their tags:
 
 |                 Image                 |         Tags          |
 |:-------------------------------------:|:---------------------:|
-| `ghcr.io/cgwalters/fedora-silverblue` | `36`, `37`, `rawhide` | 
-|  `ghcr.io/cgwalters/fedora-kinoite`   | `36`, `37`, `rawhide` | 
+| `ghcr.io/cgwalters/fedora-silverblue` | `36`, `37`, `38`, `rawhide` | 
+|  `ghcr.io/cgwalters/fedora-kinoite`   | `36`, `37`, `38`, `rawhide` | 
+
+**38 & rawhide are development branches.**


### PR DESCRIPTION
Not sure if we are still using this repo but here is a quick update to add fedora 38 since it was branched a few days ago.